### PR TITLE
Support setting session config on creation

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -36,8 +36,8 @@ type Server struct {
 }
 
 type Session struct {
-	MaxUsers int   `yaml:"max_users" json:"maxUsers"`
-	ReadOnly *bool `yaml:"read_only" json:"readOnly,omitempty"`
+	MaxUsers int  `yaml:"max_users" json:"maxUsers"`
+	ReadOnly bool `yaml:"read_only" json:"readOnly"`
 }
 
 type Github struct {

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	readOnly := false
 	want := &Configuration{}
 	want.App.Name = "boardsite-server"
 	want.App.Version = "1.0.0"
@@ -22,7 +21,7 @@ func TestNew(t *testing.T) {
 	want.Cache.Host = "localhost"
 	want.Cache.Port = 6379
 	want.Session.MaxUsers = 4
-	want.Session.ReadOnly = &readOnly
+	want.Session.ReadOnly = false
 	want.Github.ClientId = "client-Id"
 	want.Github.ClientSecret = "client-Secret"
 	want.Github.RedirectURI = "http://localhost:3000"

--- a/api/github/githubfakes/fake_client.go
+++ b/api/github/githubfakes/fake_client.go
@@ -37,7 +37,7 @@ type FakeClient struct {
 		result1 *github.TokenResponse
 		result2 error
 	}
-	invocations      map[string][][]any
+	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
@@ -50,7 +50,7 @@ func (fake *FakeClient) GetUserEmails(arg1 context.Context, arg2 string) ([]gith
 	}{arg1, arg2})
 	stub := fake.GetUserEmailsStub
 	fakeReturns := fake.getUserEmailsReturns
-	fake.recordInvocation("GetUserEmails", []any{arg1, arg2})
+	fake.recordInvocation("GetUserEmails", []interface{}{arg1, arg2})
 	fake.getUserEmailsMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -115,7 +115,7 @@ func (fake *FakeClient) PostToken(arg1 context.Context, arg2 string) (*github.To
 	}{arg1, arg2})
 	stub := fake.PostTokenStub
 	fakeReturns := fake.postTokenReturns
-	fake.recordInvocation("PostToken", []any{arg1, arg2})
+	fake.recordInvocation("PostToken", []interface{}{arg1, arg2})
 	fake.postTokenMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -171,28 +171,28 @@ func (fake *FakeClient) PostTokenReturnsOnCall(i int, result1 *github.TokenRespo
 	}{result1, result2}
 }
 
-func (fake *FakeClient) Invocations() map[string][][]any {
+func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.getUserEmailsMutex.RLock()
 	defer fake.getUserEmailsMutex.RUnlock()
 	fake.postTokenMutex.RLock()
 	defer fake.postTokenMutex.RUnlock()
-	copiedInvocations := map[string][][]any{}
+	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
 	}
 	return copiedInvocations
 }
 
-func (fake *FakeClient) recordInvocation(key string, args []any) {
+func (fake *FakeClient) recordInvocation(key string, args []interface{}) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
-		fake.invocations = map[string][][]any{}
+		fake.invocations = map[string][][]interface{}{}
 	}
 	if fake.invocations[key] == nil {
-		fake.invocations[key] = [][]any{}
+		fake.invocations[key] = [][]interface{}{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }

--- a/api/github/githubfakes/fake_handler.go
+++ b/api/github/githubfakes/fake_handler.go
@@ -31,7 +31,7 @@ type FakeHandler struct {
 	getCallbackReturnsOnCall map[int]struct {
 		result1 error
 	}
-	invocations      map[string][][]any
+	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
@@ -43,7 +43,7 @@ func (fake *FakeHandler) GetAuthorize(arg1 echo.Context) error {
 	}{arg1})
 	stub := fake.GetAuthorizeStub
 	fakeReturns := fake.getAuthorizeReturns
-	fake.recordInvocation("GetAuthorize", []any{arg1})
+	fake.recordInvocation("GetAuthorize", []interface{}{arg1})
 	fake.getAuthorizeMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -104,7 +104,7 @@ func (fake *FakeHandler) GetCallback(arg1 echo.Context) error {
 	}{arg1})
 	stub := fake.GetCallbackStub
 	fakeReturns := fake.getCallbackReturns
-	fake.recordInvocation("GetCallback", []any{arg1})
+	fake.recordInvocation("GetCallback", []interface{}{arg1})
 	fake.getCallbackMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -157,28 +157,28 @@ func (fake *FakeHandler) GetCallbackReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeHandler) Invocations() map[string][][]any {
+func (fake *FakeHandler) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.getAuthorizeMutex.RLock()
 	defer fake.getAuthorizeMutex.RUnlock()
 	fake.getCallbackMutex.RLock()
 	defer fake.getCallbackMutex.RUnlock()
-	copiedInvocations := map[string][][]any{}
+	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
 	}
 	return copiedInvocations
 }
 
-func (fake *FakeHandler) recordInvocation(key string, args []any) {
+func (fake *FakeHandler) recordInvocation(key string, args []interface{}) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
-		fake.invocations = map[string][][]any{}
+		fake.invocations = map[string][][]interface{}{}
 	}
 	if fake.invocations[key] == nil {
-		fake.invocations[key] = [][]any{}
+		fake.invocations[key] = [][]interface{}{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }

--- a/api/github/githubfakes/fake_validator.go
+++ b/api/github/githubfakes/fake_validator.go
@@ -21,7 +21,7 @@ type FakeValidator struct {
 	validateReturnsOnCall map[int]struct {
 		result1 error
 	}
-	invocations      map[string][][]any
+	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
@@ -34,7 +34,7 @@ func (fake *FakeValidator) Validate(arg1 context.Context, arg2 string) error {
 	}{arg1, arg2})
 	stub := fake.ValidateStub
 	fakeReturns := fake.validateReturns
-	fake.recordInvocation("Validate", []any{arg1, arg2})
+	fake.recordInvocation("Validate", []interface{}{arg1, arg2})
 	fake.validateMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -87,26 +87,26 @@ func (fake *FakeValidator) ValidateReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeValidator) Invocations() map[string][][]any {
+func (fake *FakeValidator) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.validateMutex.RLock()
 	defer fake.validateMutex.RUnlock()
-	copiedInvocations := map[string][][]any{}
+	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
 	}
 	return copiedInvocations
 }
 
-func (fake *FakeValidator) recordInvocation(key string, args []any) {
+func (fake *FakeValidator) recordInvocation(key string, args []interface{}) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
-		fake.invocations = map[string][][]any{}
+		fake.invocations = map[string][][]interface{}{}
 	}
 	if fake.invocations[key] == nil {
-		fake.invocations[key] = [][]any{}
+		fake.invocations[key] = [][]interface{}{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }

--- a/api/middleware/monitoring.go
+++ b/api/middleware/monitoring.go
@@ -8,7 +8,7 @@ import (
 	"github.com/heat1q/boardsite/api/metrics"
 )
 
-func Monitoring(metrics metrics.Handler) func(echo.HandlerFunc) echo.HandlerFunc {
+func Monitoring() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			meta := make(map[string]any, 2)
@@ -22,10 +22,13 @@ func Monitoring(metrics metrics.Handler) func(echo.HandlerFunc) echo.HandlerFunc
 			ctx := log.WrapCtx(c.Request().Context(), meta)
 			c.SetRequest(c.Request().WithContext(ctx))
 
-			// collect prometheus metrics
-			return metrics.MiddlewareFunc()(next)(c)
+			return next(c)
 		}
 	}
+}
+
+func Metrics(metrics metrics.Handler) echo.MiddlewareFunc {
+	return metrics.MiddlewareFunc()
 }
 
 func newTraceID() string {

--- a/api/middleware/monitoring_test.go
+++ b/api/middleware/monitoring_test.go
@@ -5,20 +5,15 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/heat1q/boardsite/session/sessionfakes"
-
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
 	"github.com/heat1q/boardsite/api/log"
-	"github.com/heat1q/boardsite/api/metrics"
 	"github.com/heat1q/boardsite/api/middleware"
 )
 
 func TestMonitoring(t *testing.T) {
-	dispatcher := &sessionfakes.FakeDispatcher{}
-	m := metrics.NewHandler(dispatcher)
 	t.Run("contains logger", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		rec := httptest.NewRecorder()
@@ -27,7 +22,7 @@ func TestMonitoring(t *testing.T) {
 		hndl := func(c echo.Context) error {
 			return c.NoContent(http.StatusNoContent)
 		}
-		fn := middleware.Monitoring(m)(hndl)
+		fn := middleware.Monitoring()(hndl)
 		err := fn(c)
 
 		assert.NoError(t, err)

--- a/api/server.go
+++ b/api/server.go
@@ -50,19 +50,20 @@ func (s *Server) Serve(ctx context.Context) (func() error, func() error) {
 	// set up session dispatcher/handler
 	s.session = sessionHttp.NewHandler(s.cfg.Session, s.dispatcher)
 
+	s.echo.Use(
+		middleware.Recover(),
+		middleware.Secure(),
+		apimw.CORS(s.cfg.Server.AllowedOrigins),
+		apimw.Monitoring())
+
 	if s.cfg.Metrics.Enabled {
 		s.metrics = metrics.NewHandler(s.dispatcher)
+		s.echo.Use(apimw.Metrics(s.metrics))
 	}
 
 	if s.cfg.Github.Enabled {
 		s.setupGithub(cache)
 	}
-
-	s.echo.Use(
-		middleware.Recover(),
-		middleware.Secure(),
-		apimw.CORS(s.cfg.Server.AllowedOrigins),
-		apimw.Monitoring(s.metrics))
 
 	// set routes
 	s.setRoutes()

--- a/attachment/attachmentfakes/fake_handler.go
+++ b/attachment/attachmentfakes/fake_handler.go
@@ -47,7 +47,7 @@ type FakeHandler struct {
 		result1 string
 		result2 error
 	}
-	invocations      map[string][][]any
+	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
@@ -58,7 +58,7 @@ func (fake *FakeHandler) Clear() error {
 	}{})
 	stub := fake.ClearStub
 	fakeReturns := fake.clearReturns
-	fake.recordInvocation("Clear", []any{})
+	fake.recordInvocation("Clear", []interface{}{})
 	fake.clearMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -112,7 +112,7 @@ func (fake *FakeHandler) Get(arg1 string) (io.Reader, string, error) {
 	}{arg1})
 	stub := fake.GetStub
 	fakeReturns := fake.getReturns
-	fake.recordInvocation("Get", []any{arg1})
+	fake.recordInvocation("Get", []interface{}{arg1})
 	fake.getMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -184,7 +184,7 @@ func (fake *FakeHandler) Upload(arg1 []byte) (string, error) {
 	}{arg1Copy})
 	stub := fake.UploadStub
 	fakeReturns := fake.uploadReturns
-	fake.recordInvocation("Upload", []any{arg1Copy})
+	fake.recordInvocation("Upload", []interface{}{arg1Copy})
 	fake.uploadMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -240,7 +240,7 @@ func (fake *FakeHandler) UploadReturnsOnCall(i int, result1 string, result2 erro
 	}{result1, result2}
 }
 
-func (fake *FakeHandler) Invocations() map[string][][]any {
+func (fake *FakeHandler) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.clearMutex.RLock()
@@ -249,21 +249,21 @@ func (fake *FakeHandler) Invocations() map[string][][]any {
 	defer fake.getMutex.RUnlock()
 	fake.uploadMutex.RLock()
 	defer fake.uploadMutex.RUnlock()
-	copiedInvocations := map[string][][]any{}
+	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
 	}
 	return copiedInvocations
 }
 
-func (fake *FakeHandler) recordInvocation(key string, args []any) {
+func (fake *FakeHandler) recordInvocation(key string, args []interface{}) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
-		fake.invocations = map[string][][]any{}
+		fake.invocations = map[string][][]interface{}{}
 	}
 	if fake.invocations[key] == nil {
-		fake.invocations[key] = [][]any{}
+		fake.invocations[key] = [][]interface{}{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }

--- a/redis/redisfakes/fake_handler.go
+++ b/redis/redisfakes/fake_handler.go
@@ -183,7 +183,7 @@ type FakeHandler struct {
 	updateStrokesReturnsOnCall map[int]struct {
 		result1 error
 	}
-	invocations      map[string][][]any
+	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
@@ -199,7 +199,7 @@ func (fake *FakeHandler) AddPage(arg1 context.Context, arg2 string, arg3 string,
 	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.AddPageStub
 	fakeReturns := fake.addPageReturns
-	fake.recordInvocation("AddPage", []any{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("AddPage", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.addPageMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3, arg4, arg5)
@@ -262,7 +262,7 @@ func (fake *FakeHandler) ClearPage(arg1 context.Context, arg2 string, arg3 strin
 	}{arg1, arg2, arg3})
 	stub := fake.ClearPageStub
 	fakeReturns := fake.clearPageReturns
-	fake.recordInvocation("ClearPage", []any{arg1, arg2, arg3})
+	fake.recordInvocation("ClearPage", []interface{}{arg1, arg2, arg3})
 	fake.clearPageMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
@@ -324,7 +324,7 @@ func (fake *FakeHandler) ClearSession(arg1 context.Context, arg2 string) error {
 	}{arg1, arg2})
 	stub := fake.ClearSessionStub
 	fakeReturns := fake.clearSessionReturns
-	fake.recordInvocation("ClearSession", []any{arg1, arg2})
+	fake.recordInvocation("ClearSession", []interface{}{arg1, arg2})
 	fake.clearSessionMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -384,7 +384,7 @@ func (fake *FakeHandler) ClosePool() error {
 	}{})
 	stub := fake.ClosePoolStub
 	fakeReturns := fake.closePoolReturns
-	fake.recordInvocation("ClosePool", []any{})
+	fake.recordInvocation("ClosePool", []interface{}{})
 	fake.closePoolMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -439,7 +439,7 @@ func (fake *FakeHandler) Delete(arg1 context.Context, arg2 string) error {
 	}{arg1, arg2})
 	stub := fake.DeleteStub
 	fakeReturns := fake.deleteReturns
-	fake.recordInvocation("Delete", []any{arg1, arg2})
+	fake.recordInvocation("Delete", []interface{}{arg1, arg2})
 	fake.deleteMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -502,7 +502,7 @@ func (fake *FakeHandler) DeletePage(arg1 context.Context, arg2 string, arg3 stri
 	}{arg1, arg2, arg3})
 	stub := fake.DeletePageStub
 	fakeReturns := fake.deletePageReturns
-	fake.recordInvocation("DeletePage", []any{arg1, arg2, arg3})
+	fake.recordInvocation("DeletePage", []interface{}{arg1, arg2, arg3})
 	fake.deletePageMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
@@ -564,7 +564,7 @@ func (fake *FakeHandler) Get(arg1 context.Context, arg2 string) (any, error) {
 	}{arg1, arg2})
 	stub := fake.GetStub
 	fakeReturns := fake.getReturns
-	fake.recordInvocation("Get", []any{arg1, arg2})
+	fake.recordInvocation("Get", []interface{}{arg1, arg2})
 	fake.getMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -631,7 +631,7 @@ func (fake *FakeHandler) GetPageMeta(arg1 context.Context, arg2 string, arg3 str
 	}{arg1, arg2, arg3, arg4})
 	stub := fake.GetPageMetaStub
 	fakeReturns := fake.getPageMetaReturns
-	fake.recordInvocation("GetPageMeta", []any{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("GetPageMeta", []interface{}{arg1, arg2, arg3, arg4})
 	fake.getPageMetaMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3, arg4)
@@ -693,7 +693,7 @@ func (fake *FakeHandler) GetPageRank(arg1 context.Context, arg2 string) ([]strin
 	}{arg1, arg2})
 	stub := fake.GetPageRankStub
 	fakeReturns := fake.getPageRankReturns
-	fake.recordInvocation("GetPageRank", []any{arg1, arg2})
+	fake.recordInvocation("GetPageRank", []interface{}{arg1, arg2})
 	fake.getPageRankMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -759,7 +759,7 @@ func (fake *FakeHandler) GetPageStrokes(arg1 context.Context, arg2 string, arg3 
 	}{arg1, arg2, arg3})
 	stub := fake.GetPageStrokesStub
 	fakeReturns := fake.getPageStrokesReturns
-	fake.recordInvocation("GetPageStrokes", []any{arg1, arg2, arg3})
+	fake.recordInvocation("GetPageStrokes", []interface{}{arg1, arg2, arg3})
 	fake.getPageStrokesMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
@@ -826,7 +826,7 @@ func (fake *FakeHandler) Put(arg1 context.Context, arg2 string, arg3 any, arg4 t
 	}{arg1, arg2, arg3, arg4})
 	stub := fake.PutStub
 	fakeReturns := fake.putReturns
-	fake.recordInvocation("Put", []any{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("Put", []interface{}{arg1, arg2, arg3, arg4})
 	fake.putMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3, arg4)
@@ -890,7 +890,7 @@ func (fake *FakeHandler) SetPageMeta(arg1 context.Context, arg2 string, arg3 str
 	}{arg1, arg2, arg3, arg4})
 	stub := fake.SetPageMetaStub
 	fakeReturns := fake.setPageMetaReturns
-	fake.recordInvocation("SetPageMeta", []any{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("SetPageMeta", []interface{}{arg1, arg2, arg3, arg4})
 	fake.setPageMetaMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3, arg4)
@@ -953,7 +953,7 @@ func (fake *FakeHandler) UpdateStrokes(arg1 context.Context, arg2 string, arg3 .
 	}{arg1, arg2, arg3})
 	stub := fake.UpdateStrokesStub
 	fakeReturns := fake.updateStrokesReturns
-	fake.recordInvocation("UpdateStrokes", []any{arg1, arg2, arg3})
+	fake.recordInvocation("UpdateStrokes", []interface{}{arg1, arg2, arg3})
 	fake.updateStrokesMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3...)
@@ -1006,7 +1006,7 @@ func (fake *FakeHandler) UpdateStrokesReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeHandler) Invocations() map[string][][]any {
+func (fake *FakeHandler) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.addPageMutex.RLock()
@@ -1035,21 +1035,21 @@ func (fake *FakeHandler) Invocations() map[string][][]any {
 	defer fake.setPageMetaMutex.RUnlock()
 	fake.updateStrokesMutex.RLock()
 	defer fake.updateStrokesMutex.RUnlock()
-	copiedInvocations := map[string][][]any{}
+	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
 	}
 	return copiedInvocations
 }
 
-func (fake *FakeHandler) recordInvocation(key string, args []any) {
+func (fake *FakeHandler) recordInvocation(key string, args []interface{}) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
-		fake.invocations = map[string][][]any{}
+		fake.invocations = map[string][][]interface{}{}
 	}
 	if fake.invocations[key] == nil {
-		fake.invocations[key] = [][]any{}
+		fake.invocations[key] = [][]interface{}{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }

--- a/session/config.go
+++ b/session/config.go
@@ -1,0 +1,46 @@
+package session
+
+import (
+	"github.com/heat1q/boardsite/api/config"
+	apiErrors "github.com/heat1q/boardsite/api/errors"
+)
+
+// TODO move to config
+const maxUsers = 50
+
+type Config struct {
+	ID     string `json:"id"`
+	Host   string `json:"host,omitempty"`
+	Secret string `json:"-"`
+
+	config.Session
+	Password string `json:"password"`
+}
+
+func (c *Config) Update(incoming *ConfigRequest) error {
+	if incoming == nil {
+		return nil
+	}
+	if err := incoming.Validate(); err != nil {
+		return err
+	}
+	if incoming.ReadOnly != nil {
+		c.ReadOnly = *incoming.ReadOnly
+	}
+	if incoming.Password != nil {
+		c.Password = *incoming.Password
+	}
+	return nil
+}
+
+type ConfigRequest struct {
+	ReadOnly *bool   `json:"readOnly,omitempty"`
+	Password *string `json:"password,omitempty"`
+}
+
+func (c *ConfigRequest) Validate() error {
+	if c.Password != nil && len(*c.Password) > 2<<6 {
+		return apiErrors.ErrBadRequest.Wrap(apiErrors.WithErrorf("password cannot be longer than 64 characters"))
+	}
+	return nil
+}

--- a/session/http/handler_test.go
+++ b/session/http/handler_test.go
@@ -17,11 +17,10 @@ import (
 )
 
 func Test_handler_PostCreateSession(t *testing.T) {
-	readonly := true
 	cfg := session.Config{
 		Session: config.Session{
 			MaxUsers: 20,
-			ReadOnly: &readonly,
+			ReadOnly: true,
 		},
 	}
 	scb := &sessionfakes.FakeController{}

--- a/session/http/utils.go
+++ b/session/http/utils.go
@@ -27,7 +27,7 @@ func AllowUser(c echo.Context) bool {
 	secret, _ := c.Get(SecretCtxKey).(string)
 
 	// request additionally need to check for correct secret
-	if scb.Config().ReadOnly != nil && *scb.Config().ReadOnly && c.Request().Method != http.MethodGet &&
+	if scb.Config().ReadOnly && c.Request().Method != http.MethodGet &&
 		(user.ID != scb.Config().Host || secret != scb.Config().Secret) {
 		return false
 	}

--- a/session/scb_test.go
+++ b/session/scb_test.go
@@ -23,27 +23,18 @@ func Test_controlBlock_SetConfig(t *testing.T) {
 	fakeCache := &redisfakes.FakeHandler{}
 	fakeBroadcaster := &sessionfakes.FakeBroadcaster{}
 	fakeBroadcaster.BroadcastReturns(make(chan types.Message, 100))
-	readonly := true
-	wantReadonly := false
-	password := "test1234"
-	wantPassword := "newpassword"
 	cfg := session.Config{
 		ID:     "1234",
 		Host:   "beef",
 		Secret: "potato",
 		Session: config.Session{
 			MaxUsers: 10,
-			ReadOnly: &readonly,
+			ReadOnly: true,
 		},
-		Password: &password,
+		Password: "test1234",
 	}
 	var scb session.Controller
 	var err error
-	scb, err = session.NewControlBlock(
-		cfg,
-		session.WithDispatcher(fakeDispatcher),
-		session.WithCache(fakeCache),
-		session.WithBroadcaster(fakeBroadcaster))
 	require.NoError(t, err)
 	tests := []struct {
 		name string
@@ -51,26 +42,45 @@ func Test_controlBlock_SetConfig(t *testing.T) {
 		want session.Config
 	}{
 		{
-			name: "",
+			name: "new config without overwriting constant values",
 			set:  `{"readOnly":false,"maxUsers":42,"id":"test","host":"test","secret":"test","password":"newpassword"}`,
 			want: session.Config{
 				ID:     "1234",
 				Host:   "beef",
 				Secret: "potato",
 				Session: config.Session{
-					MaxUsers: 42,
-					ReadOnly: &wantReadonly,
+					MaxUsers: 10, // constant
+					ReadOnly: false,
 				},
-				Password: &wantPassword,
+				Password: "newpassword",
+			},
+		},
+		{
+			name: "remove password",
+			set:  `{"password":""}`,
+			want: session.Config{
+				ID:     "1234",
+				Host:   "beef",
+				Secret: "potato",
+				Session: config.Session{
+					MaxUsers: 10, // constant
+					ReadOnly: true,
+				},
+				Password: "",
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var cfg session.Config
+			scb, err = session.NewControlBlock(
+				cfg,
+				session.WithDispatcher(fakeDispatcher),
+				session.WithCache(fakeCache),
+				session.WithBroadcaster(fakeBroadcaster))
+			var cfg session.ConfigRequest
 			err := json.Unmarshal([]byte(tt.set), &cfg)
 			assert.NoError(t, err)
-			err = scb.SetConfig(cfg)
+			err = scb.SetConfig(&cfg)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, scb.Config())
 		})

--- a/session/sessionfakes/fake_broadcaster.go
+++ b/session/sessionfakes/fake_broadcaster.go
@@ -71,7 +71,7 @@ type FakeBroadcaster struct {
 	sendReturnsOnCall map[int]struct {
 		result1 chan<- types.Message
 	}
-	invocations      map[string][][]any
+	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
@@ -83,7 +83,7 @@ func (fake *FakeBroadcaster) Bind(arg1 session.Controller) session.Broadcaster {
 	}{arg1})
 	stub := fake.BindStub
 	fakeReturns := fake.bindReturns
-	fake.recordInvocation("Bind", []any{arg1})
+	fake.recordInvocation("Bind", []interface{}{arg1})
 	fake.bindMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -143,7 +143,7 @@ func (fake *FakeBroadcaster) Broadcast() chan<- types.Message {
 	}{})
 	stub := fake.BroadcastStub
 	fakeReturns := fake.broadcastReturns
-	fake.recordInvocation("Broadcast", []any{})
+	fake.recordInvocation("Broadcast", []interface{}{})
 	fake.broadcastMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -196,7 +196,7 @@ func (fake *FakeBroadcaster) Cache() chan<- []redis.Stroke {
 	}{})
 	stub := fake.CacheStub
 	fakeReturns := fake.cacheReturns
-	fake.recordInvocation("Cache", []any{})
+	fake.recordInvocation("Cache", []interface{}{})
 	fake.cacheMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -249,7 +249,7 @@ func (fake *FakeBroadcaster) Close() chan<- struct{} {
 	}{})
 	stub := fake.CloseStub
 	fakeReturns := fake.closeReturns
-	fake.recordInvocation("Close", []any{})
+	fake.recordInvocation("Close", []interface{}{})
 	fake.closeMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -302,7 +302,7 @@ func (fake *FakeBroadcaster) Control() chan<- types.Message {
 	}{})
 	stub := fake.ControlStub
 	fakeReturns := fake.controlReturns
-	fake.recordInvocation("Control", []any{})
+	fake.recordInvocation("Control", []interface{}{})
 	fake.controlMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -355,7 +355,7 @@ func (fake *FakeBroadcaster) Send() chan<- types.Message {
 	}{})
 	stub := fake.SendStub
 	fakeReturns := fake.sendReturns
-	fake.recordInvocation("Send", []any{})
+	fake.recordInvocation("Send", []interface{}{})
 	fake.sendMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -401,7 +401,7 @@ func (fake *FakeBroadcaster) SendReturnsOnCall(i int, result1 chan<- types.Messa
 	}{result1}
 }
 
-func (fake *FakeBroadcaster) Invocations() map[string][][]any {
+func (fake *FakeBroadcaster) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.bindMutex.RLock()
@@ -416,21 +416,21 @@ func (fake *FakeBroadcaster) Invocations() map[string][][]any {
 	defer fake.controlMutex.RUnlock()
 	fake.sendMutex.RLock()
 	defer fake.sendMutex.RUnlock()
-	copiedInvocations := map[string][][]any{}
+	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
 	}
 	return copiedInvocations
 }
 
-func (fake *FakeBroadcaster) recordInvocation(key string, args []any) {
+func (fake *FakeBroadcaster) recordInvocation(key string, args []interface{}) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
-		fake.invocations = map[string][][]any{}
+		fake.invocations = map[string][][]interface{}{}
 	}
 	if fake.invocations[key] == nil {
-		fake.invocations[key] = [][]any{}
+		fake.invocations[key] = [][]interface{}{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }

--- a/session/sessionfakes/fake_controller.go
+++ b/session/sessionfakes/fake_controller.go
@@ -191,10 +191,10 @@ type FakeController struct {
 	receiveReturnsOnCall map[int]struct {
 		result1 error
 	}
-	SetConfigStub        func(session.Config) error
+	SetConfigStub        func(*session.ConfigRequest) error
 	setConfigMutex       sync.RWMutex
 	setConfigArgsForCall []struct {
-		arg1 session.Config
+		arg1 *session.ConfigRequest
 	}
 	setConfigReturns struct {
 		result1 error
@@ -257,7 +257,7 @@ type FakeController struct {
 		arg1 context.Context
 		arg2 string
 	}
-	invocations      map[string][][]any
+	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
@@ -270,7 +270,7 @@ func (fake *FakeController) AddPages(arg1 context.Context, arg2 session.PageRequ
 	}{arg1, arg2})
 	stub := fake.AddPagesStub
 	fakeReturns := fake.addPagesReturns
-	fake.recordInvocation("AddPages", []any{arg1, arg2})
+	fake.recordInvocation("AddPages", []interface{}{arg1, arg2})
 	fake.addPagesMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -331,7 +331,7 @@ func (fake *FakeController) Allow(arg1 string) bool {
 	}{arg1})
 	stub := fake.AllowStub
 	fakeReturns := fake.allowReturns
-	fake.recordInvocation("Allow", []any{arg1})
+	fake.recordInvocation("Allow", []interface{}{arg1})
 	fake.allowMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -391,7 +391,7 @@ func (fake *FakeController) Attachments() attachment.Handler {
 	}{})
 	stub := fake.AttachmentsStub
 	fakeReturns := fake.attachmentsReturns
-	fake.recordInvocation("Attachments", []any{})
+	fake.recordInvocation("Attachments", []interface{}{})
 	fake.attachmentsMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -444,7 +444,7 @@ func (fake *FakeController) Broadcaster() session.Broadcaster {
 	}{})
 	stub := fake.BroadcasterStub
 	fakeReturns := fake.broadcasterReturns
-	fake.recordInvocation("Broadcaster", []any{})
+	fake.recordInvocation("Broadcaster", []interface{}{})
 	fake.broadcasterMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -495,7 +495,7 @@ func (fake *FakeController) Close() {
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
 	}{})
 	stub := fake.CloseStub
-	fake.recordInvocation("Close", []any{})
+	fake.recordInvocation("Close", []interface{}{})
 	fake.closeMutex.Unlock()
 	if stub != nil {
 		fake.CloseStub()
@@ -521,7 +521,7 @@ func (fake *FakeController) Config() session.Config {
 	}{})
 	stub := fake.ConfigStub
 	fakeReturns := fake.configReturns
-	fake.recordInvocation("Config", []any{})
+	fake.recordInvocation("Config", []interface{}{})
 	fake.configMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -577,7 +577,7 @@ func (fake *FakeController) GetPage(arg1 context.Context, arg2 string, arg3 bool
 	}{arg1, arg2, arg3})
 	stub := fake.GetPageStub
 	fakeReturns := fake.getPageReturns
-	fake.recordInvocation("GetPage", []any{arg1, arg2, arg3})
+	fake.recordInvocation("GetPage", []interface{}{arg1, arg2, arg3})
 	fake.getPageMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
@@ -641,7 +641,7 @@ func (fake *FakeController) GetPageRank(arg1 context.Context) ([]string, error) 
 	}{arg1})
 	stub := fake.GetPageRankStub
 	fakeReturns := fake.getPageRankReturns
-	fake.recordInvocation("GetPageRank", []any{arg1})
+	fake.recordInvocation("GetPageRank", []interface{}{arg1})
 	fake.getPageRankMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -712,7 +712,7 @@ func (fake *FakeController) GetPageSync(arg1 context.Context, arg2 []string, arg
 	}{arg1, arg2Copy, arg3})
 	stub := fake.GetPageSyncStub
 	fakeReturns := fake.getPageSyncReturns
-	fake.recordInvocation("GetPageSync", []any{arg1, arg2Copy, arg3})
+	fake.recordInvocation("GetPageSync", []interface{}{arg1, arg2Copy, arg3})
 	fake.getPageSyncMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
@@ -775,7 +775,7 @@ func (fake *FakeController) GetUsers() map[string]*session.User {
 	}{})
 	stub := fake.GetUsersStub
 	fakeReturns := fake.getUsersReturns
-	fake.recordInvocation("GetUsers", []any{})
+	fake.recordInvocation("GetUsers", []interface{}{})
 	fake.getUsersMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -828,7 +828,7 @@ func (fake *FakeController) ID() string {
 	}{})
 	stub := fake.IDStub
 	fakeReturns := fake.iDReturns
-	fake.recordInvocation("ID", []any{})
+	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -883,7 +883,7 @@ func (fake *FakeController) IsValidPage(arg1 context.Context, arg2 ...string) bo
 	}{arg1, arg2})
 	stub := fake.IsValidPageStub
 	fakeReturns := fake.isValidPageReturns
-	fake.recordInvocation("IsValidPage", []any{arg1, arg2})
+	fake.recordInvocation("IsValidPage", []interface{}{arg1, arg2})
 	fake.isValidPageMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2...)
@@ -944,7 +944,7 @@ func (fake *FakeController) KickUser(arg1 string) error {
 	}{arg1})
 	stub := fake.KickUserStub
 	fakeReturns := fake.kickUserReturns
-	fake.recordInvocation("KickUser", []any{arg1})
+	fake.recordInvocation("KickUser", []interface{}{arg1})
 	fake.kickUserMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -1005,7 +1005,7 @@ func (fake *FakeController) NewUser(arg1 session.UserRequest) (*session.User, er
 	}{arg1})
 	stub := fake.NewUserStub
 	fakeReturns := fake.newUserReturns
-	fake.recordInvocation("NewUser", []any{arg1})
+	fake.recordInvocation("NewUser", []interface{}{arg1})
 	fake.newUserMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -1068,7 +1068,7 @@ func (fake *FakeController) NumUsers() int {
 	}{})
 	stub := fake.NumUsersStub
 	fakeReturns := fake.numUsersReturns
-	fake.recordInvocation("NumUsers", []any{})
+	fake.recordInvocation("NumUsers", []interface{}{})
 	fake.numUsersMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -1124,7 +1124,7 @@ func (fake *FakeController) Receive(arg1 context.Context, arg2 *types.Message, a
 	}{arg1, arg2, arg3})
 	stub := fake.ReceiveStub
 	fakeReturns := fake.receiveReturns
-	fake.recordInvocation("Receive", []any{arg1, arg2, arg3})
+	fake.recordInvocation("Receive", []interface{}{arg1, arg2, arg3})
 	fake.receiveMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
@@ -1177,15 +1177,15 @@ func (fake *FakeController) ReceiveReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeController) SetConfig(arg1 session.Config) error {
+func (fake *FakeController) SetConfig(arg1 *session.ConfigRequest) error {
 	fake.setConfigMutex.Lock()
 	ret, specificReturn := fake.setConfigReturnsOnCall[len(fake.setConfigArgsForCall)]
 	fake.setConfigArgsForCall = append(fake.setConfigArgsForCall, struct {
-		arg1 session.Config
+		arg1 *session.ConfigRequest
 	}{arg1})
 	stub := fake.SetConfigStub
 	fakeReturns := fake.setConfigReturns
-	fake.recordInvocation("SetConfig", []any{arg1})
+	fake.recordInvocation("SetConfig", []interface{}{arg1})
 	fake.setConfigMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -1202,13 +1202,13 @@ func (fake *FakeController) SetConfigCallCount() int {
 	return len(fake.setConfigArgsForCall)
 }
 
-func (fake *FakeController) SetConfigCalls(stub func(session.Config) error) {
+func (fake *FakeController) SetConfigCalls(stub func(*session.ConfigRequest) error) {
 	fake.setConfigMutex.Lock()
 	defer fake.setConfigMutex.Unlock()
 	fake.SetConfigStub = stub
 }
 
-func (fake *FakeController) SetConfigArgsForCall(i int) session.Config {
+func (fake *FakeController) SetConfigArgsForCall(i int) *session.ConfigRequest {
 	fake.setConfigMutex.RLock()
 	defer fake.setConfigMutex.RUnlock()
 	argsForCall := fake.setConfigArgsForCall[i]
@@ -1247,7 +1247,7 @@ func (fake *FakeController) SyncSession(arg1 context.Context, arg2 session.PageS
 	}{arg1, arg2})
 	stub := fake.SyncSessionStub
 	fakeReturns := fake.syncSessionReturns
-	fake.recordInvocation("SyncSession", []any{arg1, arg2})
+	fake.recordInvocation("SyncSession", []interface{}{arg1, arg2})
 	fake.syncSessionMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -1310,7 +1310,7 @@ func (fake *FakeController) UpdatePages(arg1 context.Context, arg2 session.PageR
 	}{arg1, arg2, arg3})
 	stub := fake.UpdatePagesStub
 	fakeReturns := fake.updatePagesReturns
-	fake.recordInvocation("UpdatePages", []any{arg1, arg2, arg3})
+	fake.recordInvocation("UpdatePages", []interface{}{arg1, arg2, arg3})
 	fake.updatePagesMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
@@ -1372,7 +1372,7 @@ func (fake *FakeController) UpdateUser(arg1 session.User, arg2 session.UserReque
 	}{arg1, arg2})
 	stub := fake.UpdateUserStub
 	fakeReturns := fake.updateUserReturns
-	fake.recordInvocation("UpdateUser", []any{arg1, arg2})
+	fake.recordInvocation("UpdateUser", []interface{}{arg1, arg2})
 	fake.updateUserMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -1434,7 +1434,7 @@ func (fake *FakeController) UserConnect(arg1 string, arg2 *websocket.Conn) error
 	}{arg1, arg2})
 	stub := fake.UserConnectStub
 	fakeReturns := fake.userConnectReturns
-	fake.recordInvocation("UserConnect", []any{arg1, arg2})
+	fake.recordInvocation("UserConnect", []interface{}{arg1, arg2})
 	fake.userConnectMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -1494,7 +1494,7 @@ func (fake *FakeController) UserDisconnect(arg1 context.Context, arg2 string) {
 		arg2 string
 	}{arg1, arg2})
 	stub := fake.UserDisconnectStub
-	fake.recordInvocation("UserDisconnect", []any{arg1, arg2})
+	fake.recordInvocation("UserDisconnect", []interface{}{arg1, arg2})
 	fake.userDisconnectMutex.Unlock()
 	if stub != nil {
 		fake.UserDisconnectStub(arg1, arg2)
@@ -1520,7 +1520,7 @@ func (fake *FakeController) UserDisconnectArgsForCall(i int) (context.Context, s
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeController) Invocations() map[string][][]any {
+func (fake *FakeController) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.addPagesMutex.RLock()
@@ -1567,21 +1567,21 @@ func (fake *FakeController) Invocations() map[string][][]any {
 	defer fake.userConnectMutex.RUnlock()
 	fake.userDisconnectMutex.RLock()
 	defer fake.userDisconnectMutex.RUnlock()
-	copiedInvocations := map[string][][]any{}
+	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
 	}
 	return copiedInvocations
 }
 
-func (fake *FakeController) recordInvocation(key string, args []any) {
+func (fake *FakeController) recordInvocation(key string, args []interface{}) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
-		fake.invocations = map[string][][]any{}
+		fake.invocations = map[string][][]interface{}{}
 	}
 	if fake.invocations[key] == nil {
-		fake.invocations[key] = [][]any{}
+		fake.invocations[key] = [][]interface{}{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }

--- a/session/sessionfakes/fake_dispatcher.go
+++ b/session/sessionfakes/fake_dispatcher.go
@@ -79,7 +79,7 @@ type FakeDispatcher struct {
 	numUsersReturnsOnCall map[int]struct {
 		result1 int
 	}
-	invocations      map[string][][]any
+	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
@@ -92,7 +92,7 @@ func (fake *FakeDispatcher) Close(arg1 context.Context, arg2 string) error {
 	}{arg1, arg2})
 	stub := fake.CloseStub
 	fakeReturns := fake.closeReturns
-	fake.recordInvocation("Close", []any{arg1, arg2})
+	fake.recordInvocation("Close", []interface{}{arg1, arg2})
 	fake.closeMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -154,7 +154,7 @@ func (fake *FakeDispatcher) Create(arg1 context.Context, arg2 session.Config) (s
 	}{arg1, arg2})
 	stub := fake.CreateStub
 	fakeReturns := fake.createReturns
-	fake.recordInvocation("Create", []any{arg1, arg2})
+	fake.recordInvocation("Create", []interface{}{arg1, arg2})
 	fake.createMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -218,7 +218,7 @@ func (fake *FakeDispatcher) GetSCB(arg1 string) (session.Controller, error) {
 	}{arg1})
 	stub := fake.GetSCBStub
 	fakeReturns := fake.getSCBReturns
-	fake.recordInvocation("GetSCB", []any{arg1})
+	fake.recordInvocation("GetSCB", []interface{}{arg1})
 	fake.getSCBMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -282,7 +282,7 @@ func (fake *FakeDispatcher) IsValid(arg1 string) bool {
 	}{arg1})
 	stub := fake.IsValidStub
 	fakeReturns := fake.isValidReturns
-	fake.recordInvocation("IsValid", []any{arg1})
+	fake.recordInvocation("IsValid", []interface{}{arg1})
 	fake.isValidMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -342,7 +342,7 @@ func (fake *FakeDispatcher) NumSessions() int {
 	}{})
 	stub := fake.NumSessionsStub
 	fakeReturns := fake.numSessionsReturns
-	fake.recordInvocation("NumSessions", []any{})
+	fake.recordInvocation("NumSessions", []interface{}{})
 	fake.numSessionsMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -395,7 +395,7 @@ func (fake *FakeDispatcher) NumUsers() int {
 	}{})
 	stub := fake.NumUsersStub
 	fakeReturns := fake.numUsersReturns
-	fake.recordInvocation("NumUsers", []any{})
+	fake.recordInvocation("NumUsers", []interface{}{})
 	fake.numUsersMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -441,7 +441,7 @@ func (fake *FakeDispatcher) NumUsersReturnsOnCall(i int, result1 int) {
 	}{result1}
 }
 
-func (fake *FakeDispatcher) Invocations() map[string][][]any {
+func (fake *FakeDispatcher) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.closeMutex.RLock()
@@ -456,21 +456,21 @@ func (fake *FakeDispatcher) Invocations() map[string][][]any {
 	defer fake.numSessionsMutex.RUnlock()
 	fake.numUsersMutex.RLock()
 	defer fake.numUsersMutex.RUnlock()
-	copiedInvocations := map[string][][]any{}
+	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
 	}
 	return copiedInvocations
 }
 
-func (fake *FakeDispatcher) recordInvocation(key string, args []any) {
+func (fake *FakeDispatcher) recordInvocation(key string, args []interface{}) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
-		fake.invocations = map[string][][]any{}
+		fake.invocations = map[string][][]interface{}{}
 	}
 	if fake.invocations[key] == nil {
-		fake.invocations[key] = [][]any{}
+		fake.invocations[key] = [][]interface{}{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }

--- a/session/user.go
+++ b/session/user.go
@@ -55,7 +55,7 @@ func (scb *controlBlock) NewUser(userReq UserRequest) (*User, error) {
 		Color: userReq.Color,
 	}
 
-	if scb.Config().Password != nil && userReq.Password != *scb.Config().Password {
+	if scb.Config().Password != "" && userReq.Password != scb.Config().Password {
 		return nil, apiErrors.From(apiErrors.WrongPassword)
 	}
 	if err := user.validate(); err != nil {

--- a/session/user_test.go
+++ b/session/user_test.go
@@ -18,7 +18,6 @@ func Test_controlBlock_NewUser(t *testing.T) {
 	cache := &redisfakes.FakeHandler{}
 	broadcaster := &sessionfakes.FakeBroadcaster{}
 	broadcaster.BroadcastReturns(make(chan types.Message, 999))
-	password := "password"
 
 	tests := []struct {
 		name    string
@@ -30,7 +29,7 @@ func Test_controlBlock_NewUser(t *testing.T) {
 		{
 			name: "happy path",
 			cfg: session.Config{
-				Password: &password,
+				Password: "password",
 				Session:  config.Session{MaxUsers: 10},
 			},
 			userReq: session.UserRequest{
@@ -53,7 +52,7 @@ func Test_controlBlock_NewUser(t *testing.T) {
 		{
 			name: "wrong password",
 			cfg: session.Config{
-				Password: &password,
+				Password: "password",
 				Session:  config.Session{MaxUsers: 10},
 			},
 			userReq: session.UserRequest{


### PR DESCRIPTION
* `POST /create` now accepts a session config to be directly set, eg.
```json
{
    "config": {
        "maxUsers": 10,
        "readOnly": true,
        "password": "password1234"
    }
}
```