### PR TITLE
Add separate `/b/create/config` endpoint

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -15,6 +15,7 @@ func (s *Server) setRoutes() {
 
 	createGroup := boardGroup.Group("/create", middleware.RateLimiting(s.cfg.Server.RPM, middleware.WithIP()))
 	createGroup.POST( /**/ "", s.session.PostCreateSession)
+	createGroup.POST( /**/ "/config", s.session.PostCreateSessionConfig, middleware.GithubAuth(&s.cfg.Github, s.validator))
 
 	configGroup := boardGroup.Group("/:id/config", middleware.Session(s.dispatcher))
 	configGroup.GET( /*  */ "", s.session.GetSessionConfig)

--- a/go.mod
+++ b/go.mod
@@ -8,13 +8,13 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/h2non/filetype v1.1.3
+	github.com/heat1q/opt v0.1.0
 	github.com/labstack/echo-contrib v0.12.0
 	github.com/labstack/echo/v4 v4.6.3
 	github.com/matoous/go-nanoid v1.5.0
 	github.com/matoous/go-nanoid/v2 v2.0.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1
 	github.com/prometheus/client_golang v1.12.1
-	github.com/samber/lo v1.11.0
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.21.0
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11
@@ -29,6 +29,7 @@ require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/labstack/gommon v0.3.1 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
@@ -44,7 +45,6 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20220209195652-db638375bc3a // indirect
-	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,7 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -145,6 +146,8 @@ github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/heat1q/opt v0.1.0 h1:UQGA3QQztgOeEMNrXCq7nlq+6sVsOphR5OID7dqbfnQ=
+github.com/heat1q/opt v0.1.0/go.mod h1:BDz2cncpNtF8rLcmrg1QYpoSRI322kvCBaVkTassZlE=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
@@ -166,6 +169,7 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/labstack/echo-contrib v0.12.0 h1:NPr1ez+XUa5s/4LujEon+32Bxg5DO6EKSW/va06pmLc=
 github.com/labstack/echo-contrib v0.12.0/go.mod h1:kR62TbwsBgmpV2HVab5iQRsQtLuhPyGqCBee88XRc4M=
 github.com/labstack/echo/v4 v4.6.3 h1:VhPuIZYxsbPmo4m9KAkMU/el2442eB7EBFFhNTTT9ac=
@@ -232,8 +236,6 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/samber/lo v1.11.0 h1:JfeYozXL1xfkhRUFOfH13ociyeiLSC/GRJjGKI668xM=
-github.com/samber/lo v1.11.0/go.mod h1:2I7tgIv8Q1SG2xEIkRq0F2i2zgxVpnyPOP0d3Gj2r+A=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=
 github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -248,7 +250,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/thoas/go-funk v0.9.1 h1:O549iLZqPpTUQ10ykd26sZhzD+rmR5pWhuElrhbC20M=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.1 h1:TVEnxayobAdVkhQfrfes2IzOB6o+z4roRkPF52WA1u4=
@@ -295,8 +296,6 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 h1:3MTrJm4PyNL9NBqvYDSj3DHl46qQakyfqfWo4jgfaEM=
-golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/session/config_test.go
+++ b/session/config_test.go
@@ -3,12 +3,10 @@ package session_test
 import (
 	"testing"
 
-	"github.com/samber/lo"
-
-	"github.com/heat1q/boardsite/api/config"
-
+	"github.com/heat1q/opt"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/heat1q/boardsite/api/config"
 	"github.com/heat1q/boardsite/session"
 )
 
@@ -23,26 +21,50 @@ func TestConfig_Update(t *testing.T) {
 		{
 			name:     "set readOnly",
 			config:   session.Config{Session: config.Session{ReadOnly: false}},
-			incoming: session.ConfigRequest{ReadOnly: lo.ToPtr[bool](true)},
+			incoming: session.ConfigRequest{ReadOnly: opt.New[bool](true)},
 			want:     session.Config{Session: config.Session{ReadOnly: true}},
 		},
 		{
 			name:     "unset readOnly",
 			config:   session.Config{Session: config.Session{ReadOnly: true}},
-			incoming: session.ConfigRequest{ReadOnly: lo.ToPtr[bool](false)},
+			incoming: session.ConfigRequest{ReadOnly: opt.New[bool](false)},
 			want:     session.Config{Session: config.Session{ReadOnly: false}},
 		},
 		{
 			name:     "set password",
 			config:   session.Config{},
-			incoming: session.ConfigRequest{Password: lo.ToPtr[string]("test1234")},
+			incoming: session.ConfigRequest{Password: opt.New[string]("test1234")},
 			want:     session.Config{Password: "test1234"},
 		},
 		{
 			name:     "unset password",
 			config:   session.Config{Password: "test1234"},
-			incoming: session.ConfigRequest{Password: lo.ToPtr[string]("")},
+			incoming: session.ConfigRequest{Password: opt.New[string]("")},
 			want:     session.Config{},
+		},
+		{
+			name:     "set long password returns error",
+			config:   session.Config{Password: "test1234"},
+			incoming: session.ConfigRequest{Password: opt.New[string]("AAAABBBBCCCCDDDDAAAABBBBCCCCDDDDAAAABBBBCCCCDDDDAAAABBBBCCCCDDDDAAAA")},
+			wantErr:  true,
+		},
+		{
+			name:     "set maxUsers",
+			config:   session.Config{},
+			incoming: session.ConfigRequest{MaxUsers: opt.New[int](5)},
+			want:     session.Config{Session: config.Session{MaxUsers: 5}},
+		},
+		{
+			name:     "unset maxUsers",
+			config:   session.Config{Session: config.Session{MaxUsers: 5}},
+			incoming: session.ConfigRequest{MaxUsers: opt.New[int](10)},
+			want:     session.Config{Session: config.Session{MaxUsers: 10}},
+		},
+		{
+			name:     "set invalid maxUsers returs error",
+			config:   session.Config{Session: config.Session{MaxUsers: 5}},
+			incoming: session.ConfigRequest{MaxUsers: opt.New[int](-1)},
+			wantErr:  true,
 		},
 	}
 	for _, tt := range tests {

--- a/session/scb_test.go
+++ b/session/scb_test.go
@@ -49,7 +49,7 @@ func Test_controlBlock_SetConfig(t *testing.T) {
 				Host:   "beef",
 				Secret: "potato",
 				Session: config.Session{
-					MaxUsers: 10, // constant
+					MaxUsers: 42,
 					ReadOnly: false,
 				},
 				Password: "newpassword",
@@ -63,7 +63,7 @@ func Test_controlBlock_SetConfig(t *testing.T) {
 				Host:   "beef",
 				Secret: "potato",
 				Session: config.Session{
-					MaxUsers: 10, // constant
+					MaxUsers: 10,
 					ReadOnly: true,
 				},
 				Password: "",


### PR DESCRIPTION
* fixes the issue where unauthorized users were able to create a session with advanced configuration
* this endpoint should be used when creating a session with config, since it validated the user token